### PR TITLE
Use camelCase consistently for privateApiKey (was privateapiKey)

### DIFF
--- a/mdb-realm/cleanup/action.yml
+++ b/mdb-realm/cleanup/action.yml
@@ -14,7 +14,7 @@ inputs:
   apiKey:
     required: true
     description: The public API key.
-  privateapiKey:
+  privateApiKey:
     required: true
     description: The private API key.
   clusterName:

--- a/mdb-realm/deleteAllClusters/action.yml
+++ b/mdb-realm/deleteAllClusters/action.yml
@@ -14,7 +14,7 @@ inputs:
   apiKey:
     required: true
     description: The public API key.
-  privateapiKey:
+  privateApiKey:
     required: true
     description: The private API key.
 runs:

--- a/mdb-realm/deploy/action.yml
+++ b/mdb-realm/deploy/action.yml
@@ -14,7 +14,7 @@ inputs:
   apiKey:
     required: true
     description: The public API key.
-  privateapiKey:
+  privateApiKey:
     required: true
     description: The private API key.
   clusterName:


### PR DESCRIPTION
Fixes this little blemish
<img width="846" alt="image" src="https://github.com/realm/ci-actions/assets/22237677/95522b4b-dae7-44e8-acee-a9da9db2b86f">
