### PR TITLE
Match kotlin in check-pr-title

### DIFF
--- a/synced-files/.github/workflows/check-pr-title.yml
+++ b/synced-files/.github/workflows/check-pr-title.yml
@@ -17,6 +17,6 @@ jobs:
       - name: Enforce PR title
         uses: realm/ci-actions/title-checker@main
         with:
-          regex: R[A-Z]{2,5}-[0-9]{1,6}
+          regex: R[A-Z]{2,6}-[0-9]{1,6}
           error-hint: Invalid PR title. Make sure it's prefixed with the JIRA ticket the PR addresses or add the no-jira-ticket label.
           ignore-labels: 'no-jira-ticket'


### PR DESCRIPTION
Kotlin is 6 characters, not 5.